### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/ironoc-pytest/security/code-scanning/2](https://github.com/conorheffron/ironoc-pytest/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block at the workflow root (above the `jobs:` key). This will ensure all jobs use reduced `GITHUB_TOKEN` permissions, adhering to the principle of least privilege. Since the workflow only checks out code and runs tests/lints, it needs only `contents: read` access. The change should be made in the `.github/workflows/python-package.yml` file directly after the workflow `name:` definition and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
